### PR TITLE
feat: 마이페이지 - 로그인 페이지로 이동

### DIFF
--- a/src/components/MyPage.jsx
+++ b/src/components/MyPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useUser } from '../context/UserContext';
 import { useNavigate } from 'react-router-dom';
 import '../styles/MyPage.css';
@@ -9,11 +9,19 @@ const MyPage = () => {
   const navigate = useNavigate();
   const [showLogout, setShowLogout] = useState(false);
 
+  useEffect(() =>{
+    if(!user) {
+      navigate('/login');
+    }
+  }, [user, navigate]);
+
   const handleLogout = () => {
     localStorage.removeItem('token');
     setUser(null);
     navigate('/');
   };
+
+  if (!user) return null; // 유저 정보가 없으면 아무것도 렌더링하지 않음
 
   return (
     <div className="mypage-wrapper">


### PR DESCRIPTION
## 요약
- 비로그인 사용자가 하단 네비게이션 바에서 마이페이지 접근 시, 중간 안내 없이 로그인 페이지로 바로 이동하도록 수정

## 내용
- MyPage.jsx에서 useEffect를 통해 로그인 상태를 확인
- 로그인하지 않은 경우 useNavigate로 '/login' 경로로 이동 처리
- useEffect 미사용 오류 해결 (useEffect import 추가)

## 이슈
- 기존에는 "로그인이 필요합니다 → 로그인하기" 단계가 있었으나 UX 흐름상 간결하지 않음
