### PR TITLE
fix: dummyPosts import 오류 수정 및 fetch 방식으로 변경

### DIFF
--- a/src/components/BoardDetailPage.jsx
+++ b/src/components/BoardDetailPage.jsx
@@ -1,11 +1,22 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 // import { Posts } from '../data/boardData'; // 실제 데이터 가져올 경우
-import {dummyPosts} from '../data/dummyPosts';
+import { useState, useEffect } from 'react';
 
 function BoardDetailPage() {
   const { id } = useParams();
-  const post = dummyPosts.find((p) => p.id === parseInt(id));
+  const [post, setPost] = useState(null);
+
+
+useEffect(() => {
+  fetch('/data/dummyPosts.json')
+    .then((res) => res.json())
+    .then((data) => {
+      const found = data.find((p) => p.id === parseInt(id));
+      setPost(found);
+    })
+    .catch((err) => console.error('게시글 로딩 실패:', err));
+}, [id]);
 
   if (!post) return <p>해당 게시글을 찾을 수 없습니다.</p>;
 

--- a/src/components/BoardPage.jsx
+++ b/src/components/BoardPage.jsx
@@ -1,12 +1,20 @@
-import React from 'react';
+
 // import { Posts } from '../data/boardData'; // 실제 데이터 가져올 경우
-import { dummyPosts } from '../data/dummyPosts'; // 테스트 데이터
+import React, { useEffect, useState } from 'react';
 import '../styles/BoardPage.css';
 import { useNavigate } from 'react-router-dom';
 
 
 function BoardPage() {
   const navigate = useNavigate();
+  const [posts, setPosts] = useState([]);
+
+    useEffect(() => {
+    fetch('/data/dummyPosts.json') // public/data 안의 JSON 파일 접근
+      .then((res) => res.json())
+      .then((data) => setPosts(data))
+      .catch((err) => console.error('게시글 데이터를 불러오는 데 실패했습니다.', err));
+  }, []);
 
   const handleClick = (id) => {
     navigate(`/board/${id}`);
@@ -31,7 +39,7 @@ function BoardPage() {
         <button className="write-button" onClick={handleWrite}>글 작성</button>
       </div>
       <div className="post-list">
-        {dummyPosts.map((post) => (
+        {posts.map((post) => (
           <div key={post.id} className="post-card" onClick={() => handleClick(post.id)}>
             <h3>{post.title}</h3>
             <div className="post-meta">


### PR DESCRIPTION
## 요약
기존에 import 방식으로 연결된 dummyPosts 데이터가 public 폴더로 이동하면서 발생한 모듈 불러오기 오류를 수정

## 내용
- BoardPage.jsx에서 dummyPosts import 제거 → fetch 방식으로 변경
- BoardDetailPage.jsx에서도 동일한 방식 적용
- dummyPosts.json을 public/data 경로 기준으로 요청하도록 수정

## 이슈
- 컴파일 에러 발생 (Can't resolve '../data/dummyPosts')

## 참고자료(선택)
- 없음
