### PR TITLE
feat: 뉴스 캐러셀 및 전체 뉴스 페이지 추가, FAQ 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
         "react-icons": "^5.5.0",
         "react-router-dom": "^6.30.0",
         "react-scripts": "5.0.1",
+        "react-slick": "^0.30.3",
+        "slick-carousel": "^1.8.1",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -5667,6 +5669,12 @@
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "license": "MIT"
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/clean-css": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
@@ -6958,6 +6966,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/enquire.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
+      "integrity": "sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw==",
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "2.2.0",
@@ -10904,6 +10918,13 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11010,6 +11031,15 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "license": "MIT"
+    },
+    "node_modules/json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-convert": "^0.2.0"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -14181,6 +14211,23 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/react-slick": {
+      "version": "0.30.3",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.30.3.tgz",
+      "integrity": "sha512-B4x0L9GhkEWUMApeHxr/Ezp2NncpGc+5174R02j+zFiWuYboaq98vmxwlpafZfMjZic1bjdIqqmwLDcQY0QaFA==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "enquire.js": "^2.1.6",
+        "json2mq": "^0.2.0",
+        "lodash.debounce": "^4.0.8",
+        "resize-observer-polyfill": "^1.5.0"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -14413,6 +14460,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -15201,6 +15254,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/slick-carousel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jquery": ">=1.8.0"
+      }
+    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -15470,6 +15532,12 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
+    },
+    "node_modules/string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
+      "license": "MIT"
     },
     "node_modules/string-length": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "react-icons": "^5.5.0",
     "react-router-dom": "^6.30.0",
     "react-scripts": "5.0.1",
+    "react-slick": "^0.30.3",
+    "slick-carousel": "^1.8.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.css
+++ b/src/App.css
@@ -18,10 +18,29 @@
 }
 
 .app-header{
-  color: #ffffff;
-  text-align: center;
-
+  padding: 12px 24px;
+  background-color: #ffffff;
+  border-bottom: 1px solid #eee;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.03);
+  position: sticky;
+  top: 0;
+  z-index: 999;
 }
+
+.app-header h1 {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin: 0;
+  padding: 12px 24px;
+  color: #3b49df;
+  background-color: white;
+  border-bottom: 1px solid #eee;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.03);
+  position: sticky;
+  top: 0;
+  z-index: 999;
+}
+
 
 .app-footer {
   background-color: #5f5777;
@@ -31,3 +50,40 @@
   padding: 16px 0 8px 0;
   margin-top: auto;
 }
+
+.page-title {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #3b49df; 
+  margin: 16px 0 12px;
+  text-align: center;
+  letter-spacing: 0px;
+  line-height: 1.2;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.08);
+  cursor: pointer;
+  position: relative;
+  transition: color 0.2s ease;
+}
+
+.page-title:hover {
+  color: #2a36c6;
+}
+
+.page-title::after {
+  content: "";
+  position: absolute;
+  bottom: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 64px;
+  height: 3px;
+  background-color: #3b49df;
+  border-radius: 2px;
+  opacity: 0.8;
+  transition: width 0.3s ease;
+}
+.page-title:hover::after {
+  width: 80px; 
+  background-color: #2a36c6; 
+}
+

--- a/src/App.js
+++ b/src/App.js
@@ -17,22 +17,26 @@ import KakaoCallback from './components/KakaoCallback';
 import MyPage from './components/MyPage';
 import Layout from './components/Layout';
 import SearchResultPage from './components/SearchResultPage';
-
+import NewsPage from './components/NewsPage';
+import "slick-carousel/slick/slick.css"; 
+import "slick-carousel/slick/slick-theme.css";
 
 function App() {
   const navigate = useNavigate();
   
+  const handleClickTitle = () => {
+    navigate('/');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
   return (
     <UserProvider>{/* 사용자 정보를 관리하는 Context */}
     <FormProvider>{/* FormProvider를 사용하여 폼 상태를 관리 */}
     
     <div className="app-container">
       <header className="app-header">
-        <h1 
-          onClick={() => navigate('/')} 
-          style={{ cursor: 'pointer' , color: '#003cff' }}
-        >
-          전세가드
+        <h1 onClick={handleClickTitle}className="page-title" >
+          <span className="logo-icon">🏠</span> 전세가드
         </h1>
       </header>
       <main className="app-main">
@@ -48,6 +52,7 @@ function App() {
             <Route path="/analysis" element={<ReportPage />} />
             <Route path="/mypage" element={<MyPage />} />
             <Route path="/search" element={<SearchResultPage />} />
+            <Route path="/news" element={<NewsPage />} />
           </Route>         
           
           {/* 개별 페이지 라우트 설정 */}

--- a/src/components/FaqList.jsx
+++ b/src/components/FaqList.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import '../styles/FaqList.css';
+import { IoIosArrowDown } from "react-icons/io";
+
+function FaqList({ faqItems, collapsible = false }) {
+  const [openIndex, setOpenIndex] = useState(null);
+
+  const toggle = (index) => {
+    setOpenIndex(openIndex === index ? null : index);
+  };
+
+  return (
+    <div className="faq-list">
+      <h2>자주 묻는 질문</h2>
+      {faqItems.map((item, index) => (
+        <div className="faq-card" key={index}>
+          <div className="faq-header" onClick={() => collapsible && toggle(index)}>
+            <h4>{item.question}</h4>
+            {collapsible && (
+              <IoIosArrowDown
+                className={`faq-arrow ${openIndex === index ? 'open' : ''}`}
+              />
+            )}
+          </div>
+          {(!collapsible || openIndex === index) && <p>{item.answer}</p>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default FaqList;

--- a/src/components/MainPage.jsx
+++ b/src/components/MainPage.jsx
@@ -1,29 +1,78 @@
-import { Link } from "react-router-dom";
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Link, useNavigate } from "react-router-dom";
 import SearchBar from './SearchBar';
+import NewsCarousel from './NewsCarousel';
+import FaqList from './FaqList';
 import '../styles/MainPage.css';
-import React from 'react';
 import { IoLogoWechat } from "react-icons/io5";
 import { MdDriveFolderUpload } from "react-icons/md";
 import { FaClipboardList } from "react-icons/fa";
 import { IoMdAnalytics } from "react-icons/io";
 
-
-
 function MainPage() {
-  //const user = useUser(); //로그인 상태 확인
-  // console.log(user); // 로그인 상태 확인을 위한 콘솔 로그
-  
+  const [newsItems, setNewsItems] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+  const [faqItems] = useState([
+    {
+      question: "확정일자랑 전입신고는 어떻게 다른가요?",
+      answer: "확정일자는 법원에서 받는 날짜 도장, 전입신고는 주민센터에서 주소 등록입니다. 둘 다 해야 임차인 보호됩니다."
+    },
+    {
+      question: "특약사항에 주의할 점은 무엇인가요?",
+      answer: "전입신고 금지, 계약 해지 시 위약금 과다 등은 위험합니다. AI가 자동 분석해드려요!"
+    }
+  ]);
+
+  const navigate = useNavigate();
+
+useEffect(() => {
+  axios.get('http://localhost:3000/api/news') // 백엔드 실제 API URL 변경 필요요
+    .then((res) => {
+      setNewsItems(res.data);
+      setIsLoading(false);
+    })
+    .catch((err) => {
+      console.error("뉴스 불러오기 실패. 더미 데이터로 대체합니다:", err);
+      // 더미 데이터 사용
+      setNewsItems([
+        {
+          title: "임시 뉴스 제목 1",
+          summary: "이것은 API 연결 전에 보이는 더미 뉴스입니다.",
+          date: "2025.05.15",
+          url: "#"
+        },
+        {
+          title: "임시 뉴스 제목 2",
+          summary: "뉴스 API가 준비되면 이 자리는 실제 뉴스로 바뀝니다.",
+          date: "2025.05.14",
+          url: "#"
+        }
+      ]);
+      //setHasError(true);
+      setIsLoading(false);
+    });
+}, []);
+
 
   return (
     <div className="main-page-container">
+      {/* 상단 안내 및 검색 */}      
       <div className="main-page-header">
-        <p>문서를 업로드하시면, AI가 요약 분석을 도와드립니다.</p>
-        <SearchBar /> 
+        <p className="hero-subtitle">
+             전세 계약서, 지금 업로드해보세요,<br />
+            <strong>AI가 빠르게 분석해드립니다.</strong>
+        </p>
+      <div className="search-wrapper">
+        <SearchBar />
+      </div>
       </div>
 
+      {/* 메뉴 버튼 */}
       <div className="menu-btn-container">
         <div className="menu-btns">
-          <Link to="/uploadform" className="menu-btn"><MdDriveFolderUpload className="icon"/>문서 업로드</Link>
+          <Link to="/uploadform" className="menu-btn"><MdDriveFolderUpload className="icon" />문서 업로드</Link>
         </div>
         <div className="menu-btns">
           <Link to="/" className="menu-btn"><IoMdAnalytics className="icon" />전세가율 분석</Link>
@@ -35,9 +84,33 @@ function MainPage() {
           <Link to="/analysis" className="menu-btn"><IoLogoWechat className="icon" />챗봇 상담</Link>
         </div>
       </div>
-  
+
+      {/* 뉴스 캐러셀 or 로딩/에러 처리 */}
+      <div className="info-section">
+        {isLoading ? (
+          <div className="info-box loading-box">뉴스 로딩 중입니다...</div>
+        ) : hasError ? (
+          <div className="info-box error-box">
+            <h3>뉴스 불러오기 실패</h3>
+            <p>잠시 후 다시 시도해주세요.</p>
+          </div>
+        ) : newsItems.length > 0 ? (
+          <>
+            <NewsCarousel items={newsItems} />
+            <div className="see-more-button-wrapper">
+              <button className="see-more-button" onClick={() => navigate('/news')}>
+                전체 뉴스 더보기
+              </button>
+            </div>
+          </>
+        ) : (
+          <div className="info-box empty-box">현재 표시할 뉴스가 없습니다.</div>
+        )}
+
+        <FaqList faqItems={faqItems} collapsible />
+      </div>
     </div>
   );
 }
- 
+
 export default MainPage;

--- a/src/components/NewsCarousel.jsx
+++ b/src/components/NewsCarousel.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Slider from "react-slick";
+import '../styles/NewsCarousel.css';
+
+function NewsCarousel({ items }) {
+  const settings = {
+    dots: true,
+    infinite: true,
+    autoplay: true,
+    autoplaySpeed: 4000,
+    speed: 500,
+    slidesToShow: 1,
+    slidesToScroll: 1
+  };
+
+  return (
+    <div className="news-carousel">
+      <h2>전세사기 관련 뉴스</h2>
+      <Slider {...settings}>
+        {items.map((item, index) => (
+          <div className="news-card" key={index}>
+            <a href={item.url} target="_blank" rel="noopener noreferrer">
+              <h3>{item.title}</h3>
+              <p>{item.summary}</p>
+              <small>{item.date}</small>
+            </a>
+          </div>
+        ))}
+      </Slider>
+    </div>
+  );
+}
+
+export default NewsCarousel;

--- a/src/components/NewsPage.jsx
+++ b/src/components/NewsPage.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import '../styles/NewsPage.css';
+
+const dummyNews = [
+  {
+    title: "전세가율 하락세 지속",
+    summary: "서울 외곽 지역을 중심으로 전세가율 60% 이하 하락",
+    date: "2025.05.15",
+    url: "#"
+  },
+  {
+    title: "계약 전 확인 필수 항목",
+    summary: "확정일자, 전입신고, 특약사항 주의사항 안내",
+    date: "2025.05.14",
+    url: "#"
+  },
+  {
+    title: "악성 임대인 목록 공개 예정",
+    summary: "전세사기 피해 예방을 위한 공공 데이터 활용 방안",
+    date: "2025.05.12",
+    url: "#"
+  }
+];
+
+function NewsPage() {
+  return (
+    <div className="news-page-container">
+      <h2 className="news-page-title">전체 뉴스</h2>
+      <div className="news-list">
+        {dummyNews.map((item, index) => (
+          <a href={item.url} key={index} className="news-item">
+            <div className="news-item-content">
+              <h3>{item.title}</h3>
+              <p>{item.summary}</p>
+              <small>{item.date}</small>
+            </div>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default NewsPage;

--- a/src/styles/FaqList.css
+++ b/src/styles/FaqList.css
@@ -1,0 +1,55 @@
+.faq-list {
+  margin: 12px auto;
+  max-width: 800px;
+  padding: 16px;
+  background: #f9f9f9;
+  border-radius: 16px;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.05);
+}
+
+.faq-card {
+  background: white;
+  border-left: 5px solid #4a90e2;
+  padding: 16px 20px;
+  margin-bottom: 16px;
+  border-radius: 10px;
+}
+
+.faq-card h4 {
+  font-weight: bold;
+  margin-bottom: 8px;
+}
+
+.faq-card p {
+  margin: 0;
+  color: #555;
+  font-size: 0.95rem;
+}
+
+.faq-list h2 {
+  margin-bottom: 10px; /* 제목 아래 간격 */
+}
+
+.faq-card {
+  background: #fff;
+  border-left: 4px solid #4a90e2;
+  padding: 12px 16px;
+  margin-bottom: 12px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.faq-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.faq-arrow {
+  transition: transform 0.3s ease;
+  font-size: 20px;
+}
+
+.faq-arrow.open {
+  transform: rotate(180deg);
+}

--- a/src/styles/MainPage.css
+++ b/src/styles/MainPage.css
@@ -26,6 +26,12 @@
   background-color: transparent;
 }
 
+.search-wrapper {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+
 /* Main Page Button */
 .menu-btn-container {
   display: grid;
@@ -61,4 +67,64 @@
 
 .icon {
   font-size: 3rem;              /* 글자크기(16px) 1배  1rem */
+}
+
+/*전체 뉴스 더보기 버튼 */
+
+.see-more-button-wrapper {
+  margin: 8px auto 40px auto;
+  display: flex;
+  justify-content: center;
+
+}
+
+.see-more-button {
+  padding: 12px 24px;
+  background-color: #5b7dfa;
+  color: white;
+  border: none;
+  border-radius: 12px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.see-more-button:hover {
+  background-color: #4a69d8;
+}
+
+/*메인 헤더 */
+
+.main-page-header {
+  background-color: #f7f9fc;  /* 연한 회색 톤 */
+  padding: 12px 16px 12px;
+  text-align: center;
+  border-radius: 0 0 20px 20px;
+  box-shadow: none;
+}
+
+.main-page-header p {
+  font-size: 1.05rem;
+  color: #333;
+  line-height: 1.6;
+  margin-bottom: 20px;
+}
+
+
+.main-page-header .search-bar {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.hero-subtitle {
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #444;
+  margin-bottom: 20px;
+}
+
+.hero-subtitle strong {
+  font-weight: 600;
+  color: #3b49df;
 }

--- a/src/styles/NewsCarousel.css
+++ b/src/styles/NewsCarousel.css
@@ -1,0 +1,84 @@
+.news-carousel {
+  max-width: 720px;
+  margin: 0 auto 20px;
+  padding: 20px;
+  background: #fdfdfd;
+  border-radius: 12px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.08);
+  font-family: 'Noto Sans KR', sans-serif;
+}
+
+.news-card {
+  background-color: white;
+  border-radius: 12px;
+  padding: 24px;
+  margin: 0 auto;
+  max-width: 600px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  text-align: left;
+  transition: transform 0.2s ease;
+  box-sizing: border-box;
+
+}
+
+.news-card:hover {
+  transform: translateY(-4px);
+}
+
+.news-card a {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
+.news-card h3 {
+  font-size: 1.2rem;
+  color: #222;
+  margin-bottom: 10px;
+}
+
+.news-card p {
+  font-size: 0.95rem;
+  color: #555;
+  margin-bottom: 6px;
+}
+
+.news-card small {
+  color: #999;
+  font-size: 0.8rem;
+}
+
+.slick-list {
+  padding: 0 16px !important;  
+  box-sizing: border-box;
+  overflow: hidden !important;
+}
+
+.slick-slide {
+  padding: 0 !important;
+  box-sizing: border-box;
+}
+
+
+.slick-dots {
+  bottom: -20px !important;
+  text-align: center !important;
+  position: relative !important;
+}
+
+.slick-dots li button:before {
+  font-size: 10px !important;
+  color: #ccc !important;
+  opacity: 1 !important;
+}
+
+.slick-dots li.slick-active button:before {
+  color: #24272a !important;
+  opacity: 1 !important;
+}
+
+@media (min-width: 768px) {
+  .news-card {
+    width: 600px;
+  }
+}

--- a/src/styles/NewsPage.css
+++ b/src/styles/NewsPage.css
@@ -1,0 +1,54 @@
+.news-page-container {
+  padding: 40px 20px;
+  max-width: 900px;
+  margin: 0 auto;
+  font-family: 'Noto Sans KR', sans-serif;
+}
+
+.news-page-title {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-bottom: 32px;
+  text-align: center;
+}
+
+.news-list {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.news-item {
+  text-decoration: none;
+  color: inherit;
+}
+
+.news-item-content {
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  padding: 20px;
+  background: #fff;
+  transition: background-color 0.2s ease;
+}
+
+.news-item-content:hover {
+  background-color: #f9fafe;
+}
+
+.news-item-content h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: #222;
+}
+
+.news-item-content p {
+  color: #555;
+  font-size: 0.95rem;
+  margin-bottom: 6px;
+}
+
+.news-item-content small {
+  font-size: 0.8rem;
+  color: #999;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3170,6 +3170,11 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz"
   integrity sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==
 
+classnames@^2.2.5:
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
+
 clean-css@^5.2.2:
   version "5.3.3"
   resolved "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz"
@@ -3985,6 +3990,11 @@ enhanced-resolve@^5.17.1:
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
+
+enquire.js@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz"
+  integrity sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw==
 
 entities@^2.0.0:
   version "2.2.0"
@@ -4804,11 +4814,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
-fsevents@^2.3.2, fsevents@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"
@@ -6152,6 +6157,11 @@ jiti@^1.21.6:
   resolved "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz"
   integrity sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==
 
+jquery@>=1.8.0:
+  version "3.7.1"
+  resolved "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz"
+  integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
@@ -6244,6 +6254,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
+
+json2mq@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz"
+  integrity sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==
+  dependencies:
+    string-convert "^0.2.0"
 
 json5@^1.0.2:
   version "1.0.2"
@@ -7861,7 +7878,7 @@ react-dev-utils@^12.0.1:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
-"react-dom@^18.0.0 || ^19.0.0", react-dom@^19.1.0, react-dom@>=0.14.0, react-dom@>=16.8:
+"react-dom@^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^18.0.0 || ^19.0.0", react-dom@^19.1.0, react-dom@>=0.14.0, react-dom@>=16.8:
   version "19.1.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz"
   integrity sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==
@@ -7968,7 +7985,18 @@ react-scripts@5.0.1:
   optionalDependencies:
     fsevents "^2.3.2"
 
-react@*, "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^18.0.0 || ^19.0.0", react@^19.1.0, "react@>= 16", react@>=0.14.0, react@>=16.8:
+react-slick@^0.30.3:
+  version "0.30.3"
+  resolved "https://registry.npmjs.org/react-slick/-/react-slick-0.30.3.tgz"
+  integrity sha512-B4x0L9GhkEWUMApeHxr/Ezp2NncpGc+5174R02j+zFiWuYboaq98vmxwlpafZfMjZic1bjdIqqmwLDcQY0QaFA==
+  dependencies:
+    classnames "^2.2.5"
+    enquire.js "^2.1.6"
+    json2mq "^0.2.0"
+    lodash.debounce "^4.0.8"
+    resize-observer-polyfill "^1.5.0"
+
+react@*, "react@^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^18.0.0 || ^19.0.0", react@^19.1.0, "react@>= 16", react@>=0.14.0, react@>=16.8:
   version "19.1.0"
   resolved "https://registry.npmjs.org/react/-/react-19.1.0.tgz"
   integrity sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==
@@ -8138,6 +8166,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
   integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
+
+resize-observer-polyfill@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"
@@ -8553,6 +8586,11 @@ slash@^4.0.0:
   resolved "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz"
   integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
 
+slick-carousel@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz"
+  integrity sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==
+
 sockjs@^0.3.24:
   version "0.3.24"
   resolved "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz"
@@ -8701,6 +8739,11 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
+
+string-convert@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz"
+  integrity sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==
 
 string-length@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
## 요약
- 뉴스 캐러셀 및 전체 뉴스 페이지 구현
- FAQ 구현, 전체 UI 톤 맞춰서 흐름 개선
## 내용
- NewsCarousel.jsx 추가: 메인 페이지 내 슬라이드 형태 뉴스 캐러셀 구현 (react-slick 활용)
- NewsPage.jsx 추가: /news 라우트로 전체 뉴스 목록 렌더링
- 전체 뉴스 더보기 버튼 추가 및 클릭 시 /news로 이동
- 전세가드 타이틀 스타일 개선: hover 시 밑줄, 클릭 시 scrollTo top
- 관련 스타일 파일 3종(NewsPage.css, NewsCarousel.css, FaqList.css) 신규 생성
- App.js에 해당 컴포넌트 라우팅 및 스타일 반영

## 이슈
- /news에 실제 API 연결은 아직 안 된 상태 (현재 dummy 데이터 사용)

## 참고자료(선택)
