### PR TITLE
feat: MyUploads 전세가율 추이 그래프 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.8.4",
         "chart.js": "^4.4.9",
+        "chartjs-plugin-datalabels": "^2.2.0",
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
         "react-chartjs2": "^1.2.1",
@@ -5624,6 +5625,15 @@
       },
       "engines": {
         "pnpm": ">=8"
+      }
+    },
+    "node_modules/chartjs-plugin-datalabels": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
+      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=3.0.0"
       }
     },
     "node_modules/check-types": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.8.4",
     "chart.js": "^4.4.9",
+    "chartjs-plugin-datalabels": "^2.2.0",
     "react": "^19.1.0",
     "react-chartjs-2": "^5.3.0",
     "react-chartjs2": "^1.2.1",

--- a/src/components/MyUploads.jsx
+++ b/src/components/MyUploads.jsx
@@ -1,6 +1,35 @@
 import React, { useState } from 'react';
 import '../styles/MyUploads.css';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+} from 'chart.js';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
+import { Line } from 'react-chartjs-2';
 
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+  ChartDataLabels
+);
+
+Tooltip.positioners.customAbove = function(elements, eventPosition) {
+  return {
+    x: eventPosition.x,
+    y: eventPosition.y - 200
+  };
+};
 const MyUploads = () => {
   const [address, setAddress] = useState('');
   const [bun, setBun] = useState('');
@@ -23,10 +52,7 @@ const MyUploads = () => {
       return;
     }
 
-    const requestBody = {
-      address,
-      bun,
-    };
+    const requestBody = { address, bun };
     if (ji.trim() !== '') requestBody.ji = ji;
     if (floorNumber.trim() !== '') requestBody.floorNumber = floorNumber;
 
@@ -38,7 +64,6 @@ const MyUploads = () => {
     })
       .then(res => res.json())
       .then(data => {
-        // 이중 배열 응답 처리: 실제 데이터는 [1] 번째 배열
         if (Array.isArray(data) && Array.isArray(data[1])) {
           setTransactionHistory(data[1]);
         } else {
@@ -57,36 +82,90 @@ const MyUploads = () => {
     if (!value || typeof value !== 'string') return '가격 정보 없음';
     return value.replace(/\B(?=(\d{3})+(?!\d))/g, ',') + ' 원';
   };
+  // 평형 변환하는 함수
+  const convertToPyeong = (sqm) => {
+  const pyeong = Number(sqm) / 3.3058;
+  return pyeong.toFixed(1); // 소수점 첫째 자리까지 표시
+};
+
+  const getPriceSummaryData = () => {
+    const grouped = {};
+    transactionHistory.forEach(item => {
+      const month = `${item.contractYearMonth.slice(0, 4)}.${item.contractYearMonth.slice(4)}`;
+      const rawPrice = item.price?.replace(/,/g, '');
+      const price = Number(rawPrice) / 100000000;
+      if (!grouped[month]) grouped[month] = [];
+      if (!isNaN(price)) grouped[month].push(price);
+    });
+
+    const labels = Object.keys(grouped).sort();
+    const average = [], max = [], min = [], count = [];
+
+    labels.forEach(month => {
+      const prices = grouped[month];
+      average.push(Number((prices.reduce((a, b) => a + b, 0) / prices.length).toFixed(4)));
+      max.push(Number(Math.max(...prices).toFixed(4)));
+      min.push(Number(Math.min(...prices).toFixed(4)));
+      count.push(prices.length);
+    });
+
+    return {
+      labels,
+      datasets: [
+        {
+          label: '평균 전세가',
+          data: average,
+          borderColor: 'rgba(75, 192, 192, 1)',
+          backgroundColor: 'rgba(75, 192, 192, 0.2)',
+          tension: 0,
+          yAxisID: 'y1',
+        },
+        {
+          label: '최고 전세가',
+          data: max,
+          borderColor: 'rgba(255, 99, 132, 1)',
+          backgroundColor: 'rgba(255, 99, 132, 0.2)',
+          tension: 0,
+          yAxisID: 'y1',
+        },
+        {
+          label: '최저 전세가',
+          data: min,
+          borderColor: 'rgba(255, 206, 86, 1)',
+          backgroundColor: 'rgba(255, 206, 86, 0.2)',
+          tension: 0,
+          yAxisID: 'y1',
+        },
+        {
+          label: '거래량',
+          data: count,
+          type: 'bar',
+          backgroundColor: 'rgba(153, 102, 255, 0.5)',
+          borderColor: 'rgba(153, 102, 255, 1)',
+          borderWidth: 1,
+          yAxisID: 'y2',
+          barPercentage: 0.5,
+          categoryPercentage: 0.6,
+          datalabels: {
+            anchor: 'end',
+            align: 'start',
+            color: 'black',
+            font: { weight: 'bold' },
+            formatter: (value) => `${value}건`,
+          }
+        },
+      ],
+    };
+  };
 
   return (
     <div className="mypage-subpage">
       <h2> 실거래가 직접 조회</h2>
-
       <div className="input-section">
-        <input
-          type="text"
-          placeholder="주소 (예: 경상북도 포항시 남구 오천읍 원리)"
-          value={address}
-          onChange={e => setAddress(e.target.value)}
-        />
-        <input
-          type="text"
-          placeholder="번 (예: 892)"
-          value={bun}
-          onChange={e => setBun(e.target.value)}
-        />
-        <input
-          type="text"
-          placeholder="지 (없으면 0으로 입력)"
-          value={ji}
-          onChange={e => setJi(e.target.value)}
-        />
-        <input
-          type="text"
-          placeholder="층수 "
-          value={floorNumber}
-          onChange={e => setFloorNumber(e.target.value)}
-        />
+        <input type="text" placeholder="주소" value={address} onChange={e => setAddress(e.target.value)} />
+        <input type="text" placeholder="번" value={bun} onChange={e => setBun(e.target.value)} />
+        <input type="text" placeholder="지(없으면 0)" value={ji} onChange={e => setJi(e.target.value)} />
+        <input type="text" placeholder="층수" value={floorNumber} onChange={e => setFloorNumber(e.target.value)} />
         <select value={typeCode} onChange={e => setTypeCode(Number(e.target.value))}>
           <option value={0}>아파트</option>
           <option value={1}>오피스텔</option>
@@ -94,29 +173,133 @@ const MyUploads = () => {
         </select>
         <button onClick={handleSearch}>조회하기</button>
       </div>
-
       <hr />
-
       {loading ? (
-        <p> 실거래가 불러오는 중...</p>
+        <p>실거래가 불러오는 중...</p>
       ) : transactionHistory.length > 0 ? (
-        <ul className="transaction-list">
-          {transactionHistory.map((item, idx) => (
-            <li key={idx} className="upload-card">
-              <p><strong>계약일:</strong> {item.contractYearMonth}</p>
-              <p><strong>가격:</strong> {formatPrice(item.price)}</p>
-              <p><strong>유형:</strong> {item.housingType} / {item.rentType}</p>              
-            </li>
-          ))}
-        </ul>
+        <>
+          <div className="chart-wrapper">
+            <h3>월별 평균 전세가 추이</h3>
+            <Line
+              data={getPriceSummaryData()}
+              options={{
+                responsive: true,
+                maintainAspectRatio: false,
+                interaction: {
+                  mode: 'point',
+                  intersect: true,
+                },
+                  elements: {
+                  point: {
+                    radius: 4,
+                    hitRadius: 10,
+                    hoverRadius: 6,
+                  },
+                  line: {
+                    tension: 0, // 꺾은선으로 만들기
+                  },
+                },
+
+                plugins: {
+                  legend: { position: 'top' },
+                  title: { 
+                    display: false, 
+                    text: ' ',
+                    font: {
+                      size: 16,
+                      weight: 'bold',
+                      family: 'Noto Sans KR', 
+                    },
+                    color: '#111',
+                    padding: {
+                      top: 10,
+                      bottom: 20,
+                   },
+                  },
+                  tooltip: {
+                    position: 'customAbove', // 아래에 정의한 커스텀 함수 이름
+                    callbacks: {
+                      label: (context) => {
+                        const label = context.dataset.label || '';
+                        const value = context.raw;
+                        return label === '거래량'
+                          ? `${label}: ${value}건`
+                          : `${label}: ${Number(value).toFixed(3)}억 원`;
+                      }
+                    }
+                  },
+                  datalabels: {
+                    display: (ctx) => ctx.dataset.label === '거래량',
+                    anchor: 'end',
+                    align: 'start',
+                    color: 'black',
+                    font: { weight: 'bold' },
+                    formatter: (value) => `${value}건`,
+                  }
+                },
+                scales: {
+                  x: {
+                    ticks: { maxRotation: 0, minRotation: 0 },
+                  },
+                  y1: {
+                    type: 'linear',
+                    position: 'left',
+                    title: {
+                      display: true,
+                      text: '전세가 (억 원)',
+                      color: '#666',
+                      font: {
+                        size: 12,
+                        weight: 'bold',
+                      },
+                    },
+                    ticks: {
+                      stepSize: 0.005,
+                      color: '#444',
+                      font: {
+                        size: 12,
+                      },
+                      callback: (value) => value.toFixed(3) + '억',
+                    },
+                  },
+
+                  y2: {
+                    type: 'linear',
+                    position: 'right',
+                    min: 0,
+                    max: 10,
+                    title: {
+                      display: false,
+                      text: '거래량 (건수)',
+                    },
+                    ticks: {
+                      display: false,
+                    },
+                    grid: { drawOnChartArea: false },
+                  },
+                },
+              }}
+              plugins={[ChartDataLabels]}
+            />
+          </div>
+          <ul className="transaction-list">
+            {transactionHistory.map((item, idx) => (
+              <li key={idx} className="upload-card">
+                <p><strong>계약일:</strong> {item.contractYearMonth.slice(0,4)}.{item.contractYearMonth.slice(4,6)}</p>
+                <p><strong>가격:</strong> {formatPrice(item.price)}</p>
+                <p><strong>유형:</strong> {item.housingType} / {item.rentType}</p>
+                <p>
+                  <strong>면적:</strong> {item.area}㎡ ({convertToPyeong(item.area)}평)
+                </p>
+              </li>
+            ))}
+          </ul>
+        </>
       ) : (
-        <p> 결과가 없습니다. 주소/번 정보를 다시 확인해주세요.</p>
+        <p>결과가 없습니다. 주소/번 정보를 다시 확인해주세요.</p>
       )}
     </div>
   );
 };
 
 export default MyUploads;
-
-// 면적 추가
-// 

--- a/src/styles/MyUploads.css
+++ b/src/styles/MyUploads.css
@@ -79,3 +79,27 @@
   font-size: 15px;
   margin-top: 8px;
 }
+
+
+.chart-wrapper {
+  margin-top: 32px;
+  margin-bottom: 32px;
+  background: #fff;
+  padding: 20px;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  overflow-x: auto;
+}
+
+/* canvas 직접 제어 */
+.chart-wrapper canvas {
+  height: 400px !important;
+  width: 100% !important;
+}
+
+.chart-wrapper h3 {
+  font-size: 24px;
+  font-weight: bold;
+  text-align: center;
+  margin-bottom: 16px;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3137,12 +3137,17 @@ char-regex@^2.0.0:
   resolved "https://registry.npmjs.org/char-regex/-/char-regex-2.0.2.tgz"
   integrity sha512-cbGOjAptfM2LVmWhwRFHEKTPkLwNddVmuqYZQt895yXwAsWsXObCG+YN4DGQ/JBtT4GP1a1lPPdio2z413LmTg==
 
-chart.js@^4.1.1, chart.js@^4.4.9, chart.js@>=2.5:
+chart.js@^4.1.1, chart.js@^4.4.9, chart.js@>=2.5, chart.js@>=3.0.0:
   version "4.4.9"
   resolved "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz"
   integrity sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==
   dependencies:
     "@kurkle/color" "^0.3.0"
+
+chartjs-plugin-datalabels@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz"
+  integrity sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==
 
 check-types@^11.2.3:
   version "11.2.3"


### PR DESCRIPTION
## 요약
feat: MyUploads 전세가율 추이 그래프 추가 및 계약일 포맷, 면적 표시 준비
## 내용
-  `src/components/MyUploads.jsx`
     - 계약일 포맷
     - 평수 계산 함수 추가
     - 그래프 컴포넌트 작성
     - 그래프 스타일 배치 조정 
## 이슈
- 면적 정보 아직 API 제공되지 않아 추후에 연결 필요
## 참고자료(선택)
