### PR TITLE
feat: 메인페이지 및 뉴스 섹션 UI 개선 및 FAQ 스타일 정리

### DIFF
--- a/src/components/MainPage.jsx
+++ b/src/components/MainPage.jsx
@@ -62,23 +62,31 @@ useEffect(() => {
       </div>
 
       {/* 메뉴 버튼 */}
-      <div className="menu-btn-container">
-        <div className="menu-btns">
-          <Link to="/uploadfile" className="menu-btn"><MdDriveFolderUpload className="icon" />문서 업로드</Link>
-        </div>
-        <div className="menu-btns">
-          <Link to="/mypage/uploads" className="menu-btn"><IoMdAnalytics className="icon" />실거래가 조회</Link>
-        </div>
-        <div className="menu-btns">
-          <Link to="/board" className="menu-btn"><FaClipboardList className="icon" />게시판</Link>
-        </div>
-        <div className="menu-btns">
-          <Link to="/faq" className="menu-btn"><IoLogoWechat className="icon" />자주 묻는 질문</Link>
-        </div>
-      </div>
+<div className="home-card-grid emphasized">
+  <Link to="/uploadfile" className="card-btn-strong">
+    <div className="icon-circle blue"><MdDriveFolderUpload /></div>
+    <span>문서 업로드</span>
+  </Link>
+  <Link to="/mypage/uploads" className="card-btn-strong">
+    <div className="icon-circle green"><IoMdAnalytics /></div>
+    <span>실거래가 조회</span>
+  </Link>
+  <Link to="/board" className="card-btn-strong">
+    <div className="icon-circle orange"><FaClipboardList /></div>
+    <span>게시판</span>
+  </Link>
+  <Link to="/faq" className="card-btn-strong">
+    <div className="icon-circle purple"><IoLogoWechat /></div>
+    <span>FAQ</span>
+  </Link>
+</div>
+
+
 
       {/* 뉴스 캐러셀 or 로딩/에러 처리 */}
-      <div className="info-section">
+      <div className="news-wrapper">
+        <h3 className="section-title">📢 최신 전세 관련 뉴스</h3>
+
         {isLoading ? (
           <div className="info-box loading-box">뉴스 로딩 중입니다...</div>
         ) : hasError ? (
@@ -88,19 +96,18 @@ useEffect(() => {
           </div>
         ) : newsItems.length > 0 ? (
           <>
-            <NewsCarousel items={newsItems} />
+            <NewsCarousel items={newsItems} />  {/* 타이틀 없이 */}
             <div className="see-more-button-wrapper">
               <button className="see-more-button" onClick={() => navigate('/news')}>
-                 + 전체 뉴스 더보기
+                + 전체 뉴스 더보기
               </button>
             </div>
           </>
         ) : (
           <div className="info-box empty-box">현재 표시할 뉴스가 없습니다.</div>
         )}
-
-        
       </div>
+
     </div>
   );
 }

--- a/src/components/NewsCarousel.jsx
+++ b/src/components/NewsCarousel.jsx
@@ -53,7 +53,7 @@ function NewsCarousel({ items }) {
 
   return (
     <div className="news-carousel">
-      <h2 className="carousel-title">전세 관련 뉴스</h2>
+      
       <Slider {...settings}>
         {chunkedItems.map((group, index) => (
           <div className="news-slide" key={index}>

--- a/src/components/NewsPage.jsx
+++ b/src/components/NewsPage.jsx
@@ -34,10 +34,16 @@ useEffect(() => {
 
   return (
     <div className="news-page-container">
-      <h2 className="news-page-title">전체 뉴스</h2>
+    <div className="news-title-banner">
+      <h2 className="news-page-title"> 전체 전세 관련 뉴스</h2>
+      <p className="news-subtitle">최신 전세 사기 예방과 관련된 정보를 모아 보여드립니다.</p>
+    </div>
 
       {isLoading ? (
-        <p className="news-loading">뉴스 로딩 중...</p>
+        <div className="loading-spinner-wrapper">
+          <div className="spinner"></div>
+          <p>뉴스 로딩 중입니다...</p>
+        </div>
       ) : hasError ? (
         <p className="news-error">뉴스를 불러오지 못했습니다.</p>
       ) : (

--- a/src/styles/GroupedFaqList.css
+++ b/src/styles/GroupedFaqList.css
@@ -1,30 +1,38 @@
 .faq-list {
-  margin: 24px auto;
+  margin: 32px auto;
   max-width: 880px;
-  padding: 24px;
-  background: #f9f9f9;
+  padding: 24px 28px;
+  background: #f7f9fc; /* 배경 조금 더 밝게 */
+  border: 1px solid #d1d5db;  /* 연한 테두리 추가 */
   border-radius: 16px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
 }
 
+/* 그룹 타이틀 */
 .faq-group-title {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 1.1rem;
+  font-size: 1.05rem;
   font-weight: 700;
-  color: #333;
-  background-color: #e9f1ff;
-  padding: 14px 18px;
+  color: #2c3e50; /* 딥그레이 블루 */
+  background-color: #eef4fb;  /* 아주 연한 블루 계열 */
+  padding: 14px 20px;
   margin-top: 24px;
-  border-left: 6px solid #4a90e2;
-  border-radius: 6px;
+  border-left: 5px solid #8cb4ea; /* 연한 하늘색 */
+  border-radius: 8px;
   cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.faq-group-title:hover {
+  background-color: #d4e6ff;
 }
 
 .faq-group-arrow {
   transition: transform 0.3s ease;
   font-size: 20px;
+  color: #5b7dbd;  /* 중간 정도의 블루 그레이 */
 }
 
 .faq-group-arrow.open {
@@ -35,25 +43,34 @@
   margin-top: 12px;
 }
 
+/* FAQ 카드 */
 .faq-card {
   background: white;
-  border-left: 4px solid #4a90e2;
-  padding: 14px 20px;
+  border: 1px solid #dbeafe;
+    border-left: 4px solid #a2c4ec; /* 연한 포인트 블루 */
+  background: #f9fbfd; /* 아주 연한 회청색 */
+  border: 1px solid #e3e8f0;  /* 은은한 테두리 */
+  padding: 16px 22px;
   margin: 16px 0;
   border-radius: 10px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.04);
+  transition: border-left 0.2s ease;
+}
+
+.faq-card:hover {
+  border-left: 5px solid #2563eb;
 }
 
 .faq-card h4 {
-  font-weight: bold;
+  font-weight: 600;
   margin-bottom: 8px;
   font-size: 1rem;
-  color: #222;
+  color: #111827;
 }
 
 .faq-card p {
   margin: 0;
-  color: #555;
-  font-size: 0.95rem;
-  line-height: 1.4;
+  color: #4b5563;
+  font-size: 0.94rem;
+  line-height: 1.5;
 }

--- a/src/styles/MainPage.css
+++ b/src/styles/MainPage.css
@@ -1,4 +1,4 @@
-/* Search */
+/* === 검색 안내 바 === */
 .search-bar-container {
   display: flex;
   align-items: center;
@@ -31,52 +31,129 @@
   margin: 0 auto;
 }
 
+/* === 메인 헤더 === */
+.main-page-header {
+  background-color: #f7f9fc;
+  padding: 16px 16px 8px;
+  text-align: center;
+  border-radius: 0 0 20px 20px;
+  margin-bottom: 8px;
+}
 
-/* Main Page Button */
-.menu-btn-container {
+.hero-subtitle {
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #444;
+  margin-bottom: 12px;
+}
+
+.hero-subtitle strong {
+  font-weight: 600;
+  color: #3b49df;
+}
+
+/* === 안내 메시지 === */
+.disabled-guide-bar {
+  display: flex;
+  align-items: center;
+  background-color: #f4f6f8;
+  padding: 10px 16px;
+  border-radius: 10px;
+  border: 1px solid #ccc;
+  margin: 12px auto;
+  max-width: 400px;
+  font-size: 14px;
+  color: #444;
+}
+
+/* === 버튼 그리드 === */
+.home-card-grid.emphasized {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 16px;
+  gap: 20px;
   padding: 16px;
-  max-width: 400px;
-  margin: 0 auto;
+  max-width: 500px;
+  margin: 24px auto;
 }
 
-.menu-btn {
-  background-color: #0066ff;
-  border-radius: 16px;
-  padding: 24px 12px;
+.card-btn-strong {
+  background-color: #ffffff;
+  border: 2px solid #e0e7ff;
+  border-radius: 20px;
+  padding: 20px 12px;
   text-align: center;
-  text-decoration: none;          /* 밑줄 제거  */
-  color: #ffffff;                    /* 기본 텍스트 색상 */
-  font-size: 1rem;
-  font-weight: 600;
-  aspect-ratio: 1 / 1;             /* 정사각형 박스 유지 */
+  color: #1f2937;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+  transition: all 0.25s ease;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  flex-direction: column;
   align-items: center;
-  transition: background-color 0.2s ease;
+  justify-content: center;
+  height: 130px;
 }
 
-.menu-btn:hover {
-  background-color: #004ec2;
+.card-btn-strong:hover {
+  transform: translateY(-2px) scale(1.01);
+  border-color: #6366f1;
+  box-shadow: 0 10px 20px rgba(99, 102, 241, 0.12);
 }
 
-
-.icon {
-  font-size: 3rem;              /* 글자크기(16px) 1배  1rem */
+.icon-circle {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  margin-bottom: 8px;
+  font-size: 1.9rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  background: linear-gradient(135deg, #60a5fa, #2563eb);
 }
 
-/*전체 뉴스 더보기 버튼 */
+.icon-circle.green {
+  background: linear-gradient(135deg, #34d399, #059669);
+}
+.icon-circle.orange {
+  background: linear-gradient(135deg, #fbbf24, #f97316);
+}
+.icon-circle.purple {
+  background: linear-gradient(135deg, #a78bfa, #7c3aed);
+}
 
+.card-btn-strong span {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #111827;
+}
 
+/* === 뉴스 === */
+.news-wrapper {
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 20px 24px;
+  margin: 32px auto 0;
+  max-width: 580px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.04);
+}
+
+.section-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #1f2937;
+  margin-bottom: 20px;
+  text-align: left;
+}
+
+.see-more-button-wrapper {
+  margin-top: 28px;
+  text-align: center;
+  border-top: 0.5px solid rgba(0, 0, 0, 0.08);
+}
 
 .see-more-button {
-  display: block;
-  margin: 20px auto;
-  padding: 12px 24px;
+  padding: 12px 84px;
   background-color: #1890ff;
   color: white;
   font-size: 16px;
@@ -85,71 +162,21 @@
   border-radius: 12px;
   cursor: pointer;
   transition: background-color 0.25s ease;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  margin: 0 auto;
+  display: inline-block;
 }
 
 .see-more-button:hover {
- background-color: #1474cc;
-}
-
-/*메인 헤더 */
-
-.main-page-header {
-  background-color: #f7f9fc;  /* 연한 회색 톤 */
-  padding: 12px 16px 12px;
-  text-align: center;
-  border-radius: 0 0 20px 20px;
-  box-shadow: none;
-}
-
-.main-page-header p {
-  font-size: 1.05rem;
-  color: #333;
-  line-height: 1.6;
-  margin-bottom: 20px;
-}
-
-
-.main-page-header .search-bar {
-  max-width: 600px;
-  margin: 0 auto;
-}
-
-.hero-subtitle {
-  font-size: 1rem;
-  line-height: 1.6;
-  color: #444;
-  margin-bottom: 20px;
-}
-
-.hero-subtitle strong {
-  font-weight: 600;
-  color: #3b49df;
-}
-
-
-
-.disabled-guide-bar {
-  display: flex;
-  align-items: center;
-  background-color: #f4f6f8;
-  padding: 12px 16px;
-  border-radius: 10px;
-  border: 1px solid #ccc;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
-  cursor: default;
+  background-color: #1474cc;
 }
 
 .disabled-guide-bar .search-icon {
   font-size: 20px;
   margin-right: 12px;
-  color: #ff6b00; /* 강조 색 */
+  color: #ff4d4f; 
 }
-
-.search-guide-text {
-  color: #444;
-  font-size: 14px;
-  line-height: 1.5;
-  pointer-events: none;
-  
+.card-btn-strong,
+.see-more-button,
+.menu-btn {
+  text-decoration: none;  /* 밑줄 제거 */
 }

--- a/src/styles/NewsCarousel.css
+++ b/src/styles/NewsCarousel.css
@@ -1,23 +1,11 @@
-/* 전체 슬라이더 영역 */
+/* 전체 뉴스 캐러셀 박스 */
 .news-carousel {
-  position: relative; /* 화살표 포지셔닝 기준 */
-  background-color: #f3f4f6;
-  border-radius: 12px;
-  padding: 20px 20px 32px;
-  margin-top: 20px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
-  max-width: 520px;
-  margin-left: auto;
-  margin-right: auto;
+  background: transparent; 
+  box-shadow: none;
+  border: none;
+  padding: 0;
 }
 
-/* 섹션 제목 */
-.carousel-title {
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: #1f2937;
-  margin-bottom: 16px;
-}
 
 /* 슬라이드 내부 */
 .news-slide {
@@ -32,10 +20,14 @@
 }
 
 .news-item {
-  padding: 12px;
-  border-bottom: 1px solid #e5e7eb;
+  padding: 10px 4px;
+  border-bottom: 1px solid #eee;
   font-size: 0.95rem;
+  background: none;         
+  box-shadow: none;           
+  border-radius: 0;          
 }
+
 
 .news-link {
   display: flex;
@@ -48,11 +40,11 @@
 
 .news-title {
   flex: 1;
-  color: #111827;
+  color: #222;
   font-weight: 500;
   padding-right: 10px;
   transition: color 0.2s;
-  line-height: 1.2;
+  line-height: 1.4;
   white-space: normal;
   overflow: hidden;
   display: -webkit-box;
@@ -72,11 +64,11 @@
   white-space: nowrap;
 }
 
+
 /* 슬라이더 dots */
 .news-carousel .slick-dots {
   position: relative;
   margin-top: -12px;
-  margin-bottom: 0px;
   padding-bottom: 0;
   text-align: center;
 }
@@ -86,13 +78,14 @@
 }
 
 .slick-dots li button:before {
-  color: #9ca3af;
+  color: #cbd5e1;
   font-size: 8px;
 }
 
 .slick-dots li.slick-active button:before {
   color: #2563eb;
 }
+
 
 /* 커스텀 화살표 */
 .custom-arrow {
@@ -101,13 +94,12 @@
   transform: translateY(-50%);
   z-index: 10;
 
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
-  background-color: rgba(255, 255, 255, 0.175); /* 반투명 흰색 */
-  
+  background-color: rgba(255, 255, 255, 0.6);
 
-  color: #6b7280; /* 기본 중간 회색 */
+  color: #6b7280;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -117,17 +109,16 @@
   transition: background-color 0.2s, color 0.2s, transform 0.2s;
 }
 
-
 .custom-arrow:hover {
-  background-color: #e5e7eb; /* hover 시 밝은 회색 */
-  color: #111827; /* hover 시 더 진한 텍스트 */
-  transform: translateY(-50%) scale(1.05);
+  background-color: #e0e6ed;
+  color: #111827;
+  transform: translateY(-50%) scale(1.1);
 }
 
 .custom-prev {
-  left: -24px;
+  left: -28px;
 }
 
 .custom-next {
-  right: -24px;
+  right: -28px;
 }

--- a/src/styles/NewsPage.css
+++ b/src/styles/NewsPage.css
@@ -47,3 +47,49 @@
   font-size: 0.75rem;
   color: #9ca3af;
 }
+
+.news-title-banner {
+  background-color: #f0f4ff;
+  padding: 24px 20px;
+  border-radius: 12px;
+  text-align: center;
+  border: 1px solid #dbeafe;
+  margin-bottom: 32px;
+  box-shadow: 0 1px 6px rgba(0,0,0,0.05);
+}
+
+.news-page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #1e3a8a;
+  margin-bottom: 8px;
+}
+
+.news-subtitle {
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.loading-spinner-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 0;
+  color: #6b7280;
+}
+
+.spinner {
+  width: 32px;
+  height: 32px;
+  border: 4px solid #d1d5db;
+  border-top: 4px solid #3b82f6;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 12px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
## 요약
feat: 메인페이지 및 뉴스 섹션 UI 개선 및 FAQ 스타일 정리
## 내용
- 메인페이지 버튼 레이아웃 및 색상 조정
- 뉴스 타이틀 및 '전체 뉴스 더보기' 버튼 UI 통일
- 전세 관련 뉴스와 최신 뉴스 통합 스타일 적용
- GroupedFaqList 디자인 개선 및 마진 간격 조정
- 불필요한 CSS 중복 제거 및 색상 톤 정리

