### PR TITLE
feat: 실거래가 전세가율 추가

### DIFF
--- a/src/components/MyUploads.jsx
+++ b/src/components/MyUploads.jsx
@@ -1,4 +1,4 @@
-import React, {useState } from 'react';
+import React, { useState } from 'react';
 import '../styles/MyUploads.css';
 import {
   Chart as ChartJS,
@@ -12,7 +12,9 @@ import {
 } from 'chart.js';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import { Line } from 'react-chartjs-2';
+import { useEffect } from 'react';
 
+// Chart.js 플러그인 등록
 ChartJS.register(
   CategoryScale,
   LinearScale,
@@ -24,131 +26,241 @@ ChartJS.register(
   ChartDataLabels
 );
 
-Tooltip.positioners.customAbove = function(elements, eventPosition) {
-  return {
-    x: eventPosition.x,
-    y: eventPosition.y - 200
-  };
-};
+
 const MyUploads = () => {
+  // 입력 상태
   const [address, setAddress] = useState('');
   const [bun, setBun] = useState('');
   const [ji, setJi] = useState('');
   const [floorNumber, setFloorNumber] = useState('');
-  const [typeCode, setTypeCode] = useState(0);
   const [area, setArea] = useState('');
+  const [typeCode, setTypeCode] = useState(0);
 
-  const [transactionHistory, setTransactionHistory] = useState([]);
+  // 결과 상태
   const [loading, setLoading] = useState(false);
+  const [jeonseData, setJeonseData] = useState([]);
+  const [saleData, setSaleData] = useState([]);
+  const [transactionHistory, setTransactionHistory] = useState([]);
 
+  // 실거래 조회 버튼 클릭 시 호출
   const handleSearch = () => {
     const base = process.env.REACT_APP_API_URL;
-    let apiUrl = '';
-    if (typeCode === 0) apiUrl = `${base}/transaction/jeonse/apartment`;
-    else if (typeCode === 1) apiUrl = `${base}/transaction/jeonse/officetel`;
-    else if (typeCode === 2) apiUrl = `${base}/transaction/jeonse/rowhouse`;
 
+    // 주택유형 코드에 따라 API URL 설정
+    let apiUrl = '';
+    if (typeCode === 0) apiUrl = `${base}/transaction/summary/apartment`;
+    else if (typeCode === 1) apiUrl = `${base}/transaction/summary/officetel`;
+    else if (typeCode === 2) apiUrl = `${base}/transaction/summary/rowhouse`;
+
+    // 입력값 검증
     if (!address.trim() || !bun.trim() || !ji.trim() || !floorNumber.trim() || !area.trim()) {
       alert('주소, 번, 지, 층수, 면적을 모두 입력해야 합니다.');
       return;
     }
 
-    const requestBody = { address, bun };
-    if (ji.trim() !== '') requestBody.ji = ji;
-    if (floorNumber.trim() !== '') requestBody.floorNumber = floorNumber;
-    if (area.trim() !== '') requestBody.area = area;
-
+    // 요청 바디 구성 (스웨거 명세와 일치)
+    const requestBody = {
+      address,
+      bun,
+      ji,
+      floorNumber,
+      area
+    };
 
     setLoading(true);
     fetch(apiUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(requestBody),
+      body: JSON.stringify(requestBody)
     })
       .then(res => res.json())
+ 
       .then(data => {
-        if (Array.isArray(data) && Array.isArray(data[1])) {
-          setTransactionHistory(data[1]);
-        } else {
-          console.error('예상과 다른 응답 구조:', data);
-          setTransactionHistory([]);
-        }
-        setLoading(false);
+        // Java 직렬화된 응답 → 각 항목이 ["java.util.ArrayList", [실제데이터]]
+        console.log("전체 응답 원본:", data);
+        const jeonseRaw = Array.isArray(data.jeonses) ? data.jeonses[1] : [];
+        const saleRaw = Array.isArray(data.sales) ? data.sales[1] : [];
+
+        console.log(" 파싱된 전세 데이터:", jeonseRaw);
+        console.log(" 파싱된 매매 데이터:", saleRaw);
+
+        setJeonseData(jeonseRaw);
+        setSaleData(saleRaw);
+        setTransactionHistory(jeonseRaw);
       })
       .catch(err => {
         console.error('API 오류:', err);
-        setLoading(false);
       });
-  };
 
+
+    setLoading(false);
+  };
+useEffect(() => {
+  // 테스트용 하드코딩 데이터
+  const sampleJeonse = [
+    {
+      contractYearMonth: "202403",
+      price: "450,000,000",
+      area: "84.96",
+      housingType: "아파트",
+      rentType: "전세"
+    },
+    {
+      contractYearMonth: "202402",
+      price: "460,000,000",
+      area: "84.96",
+      housingType: "아파트",
+      rentType: "전세"
+    }
+  ];
+
+  const sampleSale = [
+    {
+      contractYearMonth: "202403",
+      price: "600,000,000",
+      area: "84.96",
+      housingType: "아파트",
+      rentType: "매매"
+    },
+    {
+      contractYearMonth: "202402",
+      price: "580,000,000",
+      area: "84.96",
+      housingType: "아파트",
+      rentType: "매매"
+    }
+  ];
+
+  setJeonseData(sampleJeonse);
+  setSaleData(sampleSale);
+  setTransactionHistory(sampleJeonse); // 전세만 거래 리스트에
+}, []);
+
+  // 숫자에 쉼표 추가 (금액 포맷용)
   const formatPrice = (value) => {
     if (!value || typeof value !== 'string') return '가격 정보 없음';
     return value.replace(/\B(?=(\d{3})+(?!\d))/g, ',') + ' 원';
   };
-  // 평형 변환하는 함수
+
+  // 평으로 변환
   const convertToPyeong = (sqm) => {
-  const pyeong = Number(sqm) / 3.3058;
-  return pyeong.toFixed(1); // 소수점 첫째 자리까지 표시
-};
-
-const getYAxisRange = (dataArr) => {
-if (dataArr.length === 1) {
-  const val = Number(dataArr[0]);
-  return { min: val - 0.05, max: val + 0.05 };
-}
-return {}; // 기본 자동 스케일링
-};
-
-const getPriceStats = () => {
-  const prices = transactionHistory.map(item => Number(item.price?.replace(/,/g, '')) / 100000000);
-  if (prices.length === 0) return null;
-
-  const sum = prices.reduce((a, b) => a + b, 0);
-  return {
-    average: (sum / prices.length).toFixed(3),
-    max: Math.max(...prices).toFixed(3),
-    min: Math.min(...prices).toFixed(3),
-    count: prices.length
+    const pyeong = Number(sqm) / 3.3058;
+    return pyeong.toFixed(1);
   };
-};
 
-const getLineChartData = () => {
-  const grouped = {};
-  transactionHistory.forEach(item => {
-    const month = `${item.contractYearMonth.slice(0, 4)}.${item.contractYearMonth.slice(4)}`;
-    const rawPrice = item.price?.replace(/,/g, '');
-    const price = Number(rawPrice) / 100000000;
-    if (!grouped[month]) grouped[month] = [];
-    if (!isNaN(price)) grouped[month].push(price);
-  });
-
-  const labels = Object.keys(grouped).sort();
-  const average = labels.map(month => {
-    const prices = grouped[month];
-    return (prices.reduce((a, b) => a + b, 0) / prices.length).toFixed(3);
-  });
-
-
-
-  return {
-    labels,
-    datasets: [
-      {
-        label: '평균 전세가 (억 원)',
-        data: average,
-        borderColor: 'rgba(75, 192, 192, 1)',
-        backgroundColor: 'rgba(75, 192, 192, 0.2)',
-        tension: 0,
-        fill: false,
-        pointRadius: 5,
-      }
-    ]
+  const getYAxisRange = (dataArr) => {
+    if (dataArr.length === 1) {
+      const val = Number(dataArr[0]);
+      return { min: val - 0.2, max: val + 0.2 }; // 더 넓게 설정
+    } else {
+      const minVal = Math.min(...dataArr.map(Number));
+      const maxVal = Math.max(...dataArr.map(Number));
+      return {
+        min: Math.floor(minVal * 10) / 10 - 0.1,
+        max: Math.ceil(maxVal * 10) / 10 + 0.1
+      };
+    }
   };
-};
 
+  // 평균/최고/최저 전세가 통계
+  const getPriceStats = () => {
+    const prices = transactionHistory.map(item => Number(item.price?.replace(/,/g, '')) / 100000000);
+    if (prices.length === 0) return null;
+
+    const sum = prices.reduce((a, b) => a + b, 0);
+    return {
+      average: (sum / prices.length).toFixed(3),
+      max: Math.max(...prices).toFixed(3),
+      min: Math.min(...prices).toFixed(3),
+      count: prices.length
+    };
+  };
+
+  // 월별 전세가 평균 추이 그래프용 데이터
+  const getLineChartData = () => {
+    const grouped = {};
+    transactionHistory.forEach(item => {
+      const month = `${item.contractYearMonth.slice(0, 4)}.${item.contractYearMonth.slice(4)}`;
+      const rawPrice = item.price?.replace(/,/g, '');
+      const price = Number(rawPrice) / 100000000;
+      if (!grouped[month]) grouped[month] = [];
+      if (!isNaN(price)) grouped[month].push(price);
+    });
+
+    const labels = Object.keys(grouped).sort();
+    const average = labels.map(month => {
+      const prices = grouped[month];
+      return (prices.reduce((a, b) => a + b, 0) / prices.length).toFixed(3);
+    });
+
+    return {
+      labels,
+      datasets: [
+        {
+          label: ' 월별 전세 실거래 평균',
+          data: average,
+          borderColor: 'rgba(75, 192, 192, 1)',
+          backgroundColor: 'rgba(75, 192, 192, 0.2)',
+          tension: 0,
+          fill: false,
+          pointRadius: 4
+        }
+      ]
+    };
+  };
+
+  // 월별 전세가율 계산 함수 (전세/매매 평균 비율)
+  const getJeonseRateStats = () => {
+    const grouped = {};
+
+    jeonseData.forEach(item => {
+      const month = `${item.contractYearMonth.slice(0, 4)}.${item.contractYearMonth.slice(4, 6)}`;
+      const price = Number(item.price?.replace(/,/g, '')) / 100000000;
+      if (!grouped[month]) grouped[month] = { jeonse: [], sale: [] };
+      if (!isNaN(price)) grouped[month].jeonse.push(price);
+    });
+
+    saleData.forEach(item => {
+      const month = `${item.contractYearMonth.slice(0, 4)}.${item.contractYearMonth.slice(4, 6)}`;
+      const price = Number(item.price?.replace(/,/g, '')) / 100000000;
+      if (!grouped[month]) grouped[month] = { jeonse: [], sale: [] };
+      if (!isNaN(price)) grouped[month].sale.push(price);
+    });
+
+    return Object.entries(grouped)
+      .map(([month, { jeonse, sale }]) => {
+        const hasJeonse = jeonse.length > 0;
+        const hasSale = sale.length > 0;
+        if (!hasJeonse && !hasSale) return null;
+
+        const avgJeonse = hasJeonse
+          ? (jeonse.reduce((a, b) => a + b, 0) / jeonse.length).toFixed(2)
+          : null;
+        const avgSale = hasSale
+          ? (sale.reduce((a, b) => a + b, 0) / sale.length).toFixed(2)
+          : null;
+        const rate =
+          hasJeonse && hasSale && Number(avgSale) > 0
+            ? ((Number(avgJeonse) / Number(avgSale)) * 100).toFixed(2)
+            : null;
+
+        return {
+          month,
+          avgJeonse,
+          avgSale,
+          rate
+        };
+      })
+      .filter(Boolean)
+      .sort((a, b) => a.month.localeCompare(b.month));
+  };
+
+  
   return (
     <div className="mypage-subpage">
-      <h2> 실거래가 직접 조회</h2>
+      <h2>실거래가 직접 조회</h2>
+
+      {/* 입력창 영역 */}
       <div className="input-section">
         <input type="text" placeholder="주소" value={address} onChange={e => setAddress(e.target.value)} />
         <input type="text" placeholder="번" value={bun} onChange={e => setBun(e.target.value)} />
@@ -163,105 +275,157 @@ const getLineChartData = () => {
         </select>
         <button onClick={handleSearch}>조회하기</button>
       </div>
+
       <hr />
+
+      {/* 로딩 or 결과 */}
       {loading ? (
         <p>실거래가 불러오는 중...</p>
       ) : transactionHistory.length > 0 ? (
         <>
+          {/* 거래 리스트 */}
           <ul className="transaction-list">
             {transactionHistory.map((item, idx) => (
               <li key={idx} className="upload-card">
-                <p><strong>계약일:</strong> {item.contractYearMonth.slice(0,4)}.{item.contractYearMonth.slice(4,6)}</p>
+                    <p><strong>계약일: </strong> 
+                      {item.contractYearMonth 
+                        ? `${item.contractYearMonth.slice(0, 4)}.${item.contractYearMonth.slice(4, 6)}`
+                        : '정보 없음'}
+                    </p>
+                
                 <p><strong>가격:</strong> {formatPrice(item.price)}</p>
                 <p><strong>유형:</strong> {item.housingType} / {item.rentType}</p>
-                <p>
-                   <strong>면적:</strong> {item.area}㎡ ({convertToPyeong(item.area)}평)
-                </p>
+                <p><strong>면적:</strong> {item.area}㎡ ({convertToPyeong(item.area)}평)</p>
               </li>
             ))}
           </ul>
 
-              {getPriceStats() && (
-                <div className="summary-box">
-                  <p><strong>거래 건수:</strong> {getPriceStats().count}건</p>
-                  <p><strong>평균 전세가:</strong> {getPriceStats().average}억</p>
-                  <p><strong>최고 전세가:</strong> {getPriceStats().max}억</p>
-                  <p><strong>최저 전세가:</strong> {getPriceStats().min}억</p>
-                </div>
-              )}
+          {/* 전세 통계 요약 */}
+          {getPriceStats() && (
+            <div className="summary-box">
+              <p><strong>거래 건수:</strong> {getPriceStats().count}건</p>
+              <p><strong>평균 전세가:</strong> {getPriceStats().average}억</p>
+              <p><strong>최고 전세가:</strong> {getPriceStats().max}억</p>
+              <p><strong>최저 전세가:</strong> {getPriceStats().min}억</p>
+            </div>
+          )}
 
-              {getLineChartData().labels.length === 1 && (
-              <p style={{ textAlign: 'center', fontSize: '14px', color: '#666', marginTop: '12px' }}>
-                ※ 단일 거래 데이터입니다. 추이를 보기 위해 y축이 조정되었습니다.
-              </p>
-            )}
+          {/* 전세가율 요약 */}
+          {getJeonseRateStats().length > 0 ? (
+            <div className="summary-box">
+              <h3>월별 전세가율 및 평균가</h3>
+              <ul>
+                {getJeonseRateStats().map((item, idx) => {
+                  const missingClass =
+                    !item.avgJeonse && !item.avgSale
+                      ? 'both-missing'
+                      : !item.avgJeonse
+                      ? 'jeonse-missing'
+                      : !item.avgSale
+                      ? 'sale-missing'
+                      : '';
 
-
-            <div className="chart-wrapper">
-              <h3>월별 평균 전세가 추이</h3>
-              <Line
-                data={getLineChartData()}
-                options={{
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    plugins: {
-                      datalabels: {
-                        display: true,
-                        anchor: 'end',     
-                        align: 'top',      
-                        color: '#333',
-                        font: {
-                          weight: 'bold'
-                        },
-                        formatter: (value) => `${(value * 100000000).toLocaleString()}원`
-                      },
-                      tooltip: {
-                        position: 'customAbove',
-                        backgroundColor: 'rgba(0, 0, 0, 0.8)',
-                        padding: 10,
-                        bodySpacing: 6,
-                        displayColors: false,
-                        callbacks: {
-                            label: (ctx) => `${ctx.dataset.label}: ${(ctx.raw * 100000000).toLocaleString()}원`
-                        }
-                      },
-                      legend: { position: 'top' }
-                    },
-                    elements: {
-                      point: {
-                        radius: 6,
-                        borderWidth: 2,
-                        backgroundColor: '#1890ff',
-                        borderColor: '#005cbf',
-                        hoverRadius: 8,
-                      }
-                    },
-                    scales: {
-                      x: {
-                        offset: true,
-                        ticks: {
-                          align: 'center'
-                        }
-                      },
-                    y: {
-                      ...getYAxisRange(getLineChartData().datasets[0].data),
-                      title: {
-                        display: true,
-                        text: '전세가 (억 원)'
-                      },
-                      ticks: {
-                        callback: (value) => value.toFixed(2) + '억'
-                      }
-                    }
-                  }
-                }}
-              />
+                  return (
+                    <li key={idx} className={missingClass}>
+                      <strong>{item.month}</strong> –{' '}
+                      {item.rate ? (
+                        <>전세가율: <span className="rate-ok">{item.rate}%</span></>
+                      ) : (
+                        <>전세가율: <span className="rate-fail">계산 불가</span></>
+                      )}
+                      <br />
+                      전세: {item.avgJeonse ? `${item.avgJeonse}억` : '없음'} /
+                      매매: {item.avgSale ? `${item.avgSale}억` : '없음'}
+                    </li>
+                  );
+                })}
+              </ul>
 
             </div>
-          </>
-        ) : (
-          <p></p>
-        )}
+          ) : (
+            <div className="empty-result">
+              ※ 전세 또는 매매 평균가가 존재하지 않습니다.
+            </div>
+          )}
+
+
+
+
+          {/* 전세가 추이 차트 */}
+          <div className="chart-wrapper">
+            <h3>최근 전세 실거래 변화</h3>
+            <Line
+              data={getLineChartData()}
+              options={{
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                  datalabels: {
+                    display: true,
+                    anchor: 'end',
+                    align: 'top',
+                    color: '#333',
+                    font: { weight: 'bold' },
+                    formatter: (value) => `${(value * 100000000).toLocaleString()}원`
+                  },
+                  tooltip: {
+                    position: 'nearest',
+                   
+                    backgroundColor: 'rgba(0, 0, 0, 0.8)',
+                    padding: 10,
+                    bodySpacing: 6,
+                    displayColors: false,
+                    callbacks: {
+                       label: (ctx) => `전세 평균가: ${(ctx.raw * 100000000).toLocaleString()}원`
+                     
+                    }
+                  },
+                  legend: { position: 'top' }
+                },
+                elements: {
+                  point: {
+                    radius: 6,
+                    borderWidth: 2,
+                    backgroundColor: '#1890ff',
+                    borderColor: '#005cbf',
+                    hoverRadius: 8
+                  }
+                },
+                scales: {
+                  x: {
+                    offset: true,
+                    ticks: { align: 'center' }
+                  },
+                  y: {
+                    ...getYAxisRange(getLineChartData().datasets[0].data),
+                    beginAtZero: false,
+                    title: {
+                      display: true,
+                      text: '전세가 (억 원)'
+                    },
+                    ticks: {
+                      stepSize: 0.05,
+                      callback: (value) => value.toFixed(2) + '억'
+                    }
+                  }
+                }
+              }}
+              />
+          </div>
+          {/* 단일 데이터 안내 */}
+          {getLineChartData().labels.length === 1 && (
+          <p className="single-data-note">
+            ※ 단일 거래 데이터입니다. 추이를 보기 위해 y축이 조정되었습니다.
+          </p>
+          )}
+
+
+
+
+        </>
+      ) : (
+        <p></p>
+      )}
     </div>
   );
 };

--- a/src/styles/MyUploads.css
+++ b/src/styles/MyUploads.css
@@ -1,76 +1,99 @@
 .mypage-subpage {
-  max-width: 800px;
-  margin: 40px auto;
-  padding: 24px;
+  max-width: 880px;
+  margin: 48px auto;
+  padding: 32px;
   font-family: 'Noto Sans KR', sans-serif;
-  color: #333;
+  color: #222;
+  background-color: #fefefe;
 }
 
-/* 🔍 입력 영역 */
+/* 입력 영역 */
 .input-section {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   gap: 12px;
-  margin-bottom: 24px;
+  margin-bottom: 32px;
+  background: #f5f9ff;
+  padding: 20px;
+  border-radius: 12px;
+  border: 1px solid #cbe2ff;
+  box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.03);
 }
 
 .input-section input,
 .input-section select {
-  padding: 10px;
-  border: 1px solid #ddd;
+  flex: 1 1 180px;
+  min-width: 150px;
+  padding: 10px 12px;
+  border: 1px solid #ccc;
   border-radius: 8px;
   font-size: 15px;
+  background-color: #fff;
+  transition: border-color 0.2s ease;
+}
+
+.input-section input:focus,
+.input-section select:focus {
+  border-color: #1890ff;
+  outline: none;
 }
 
 .input-section button {
-  padding: 10px;
+  padding: 12px 24px;
   background-color: #1890ff;
   color: white;
   font-weight: bold;
   border: none;
   border-radius: 8px;
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: background-color 0.2s ease, transform 0.1s ease;
+  flex: 1 1 150px;
 }
 
 .input-section button:hover {
   background-color: #1474cc;
+  transform: translateY(-1px);
 }
 
-/* 📄 카드 스타일 */
+/*  거래 카드 */
 .upload-card {
   background-color: #ffffff;
   padding: 16px 20px;
-  margin-bottom: 16px;
+  margin-bottom: 20px;
   border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-  transition: transform 0.2s;
+  border-left: 5px solid #1890ff;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .upload-card:hover {
-  transform: translateY(-2px);
+  transform: translateY(-3px);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
 }
 
 .upload-card p {
   margin: 4px 0;
   font-size: 15px;
+  line-height: 1.5;
 }
 
-/* 📃 거래 리스트 영역 */
+
+/*  거래 리스트 */
 .transaction-list {
   list-style: none;
   padding: 0;
   margin: 0;
 }
 
+/*  전세가 추이 그래프 */
 .chart-wrapper {
-  margin-top: 32px;
-  margin-bottom: 32px;
-  background: #f0f8ff; /* 밝은 푸른 배경 */
-  padding: 24px;
-  border-radius: 12px;
-  border: 1px solid #91caff; /* 푸른색 테두리 */
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  margin-top: 40px;
+  margin-bottom: 40px;
+  background: #fafafa;
+  padding: 28px;
+  border-radius: 14px;
+  border: 1px solid #686a6c;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
   overflow-x: auto;
 }
 
@@ -80,22 +103,145 @@
 }
 
 .chart-wrapper h3 {
-  font-size: 24px;
+  font-size: 22px;
   font-weight: bold;
   text-align: center;
+  margin-top: 0;
+  margin-bottom: 10px;
+  color: #373b3f;
+}
+
+/*  요약 박스 (전세가율 + 평균가) */
+.summary-box {
+  margin: 24px 0;
+  background-color: #fdfdfd;
+  padding: 20px 24px;
+  border-radius: 12px;
+  border-left: 3px solid #93c3f0;
+  box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.03);
+  font-size: 15px;
+  color: #333;
+
+}
+
+.summary-box h3 {
+  font-size: 20px;
+  color: #1c4e83;
   margin-bottom: 16px;
+}
+
+/*  전세가율 리스트 */
+.summary-box ul {
+   display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 0;
+  margin: 0;
+}
+
+.summary-box ul li {
+  list-style: none;
+  background: #ffffff;
+  border: 1px solid #e0e0e0;
+  border-radius: 10px;
+  padding: 14px 16px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.03);
+  transition: background-color 0.2s;
+  font-size: 14px;
+  line-height: 1.6;
+  color: #333;
+}
+
+/*  전세가율 강조 색상 */
+.summary-box ul li strong {
   color: #005cbf;
 }
 
-.summary-box {
-  margin: 20px 0;
-  background-color: #f9f9f9;
-  padding: 16px 20px;
-  border-radius: 8px;
-  border-left: 4px solid #1890ff; /* 왼쪽 파란색 바 */
-  box-shadow: inset 0 0 3px rgba(0, 0, 0, 0.05);
-  font-size: 15px;
-  color: #333;
-  line-height: 1.6;
+
+
+span.rate-fail {
+  color: #999;
+  font-weight: normal;
 }
+
+span.rate-ok {
+  color: #1890ff;
+  font-weight: bold;
+}
+.summary-box li .rate-ok {
+  color: #1890ff;
+  font-weight: bold;
+}
+
+/* ⚠️ 전세가율 없음 회색 */
+.summary-box li .rate-fail {
+  color: #999;
+  
+  font-weight: normal;
+}
+
+/* 전세 없음 표시 배경 강조 */
+.summary-box li.jeonse-missing {
+  background-color: #fff5f5;
+  border-left-color: #ff4d4f;
+}
+
+/*  매매 없음 표시 배경 강조 */
+.summary-box li.sale-missing {
+  background-color: #f0f8ff;
+  border-left-color: #1890ff;
+}
+
+/*  둘 다 없음 */
+.summary-box li.both-missing {
+  background-color: #f5f5f5;
+  border-left-color: #bbb;
+  font-style: italic;
+  color: #999;
+}
+
+/* 모바일 대응 */
+@media (max-width: 640px) {
+  .input-section {
+    flex-direction: column;
+  }
+
+  .input-section input,
+  .input-section select,
+  .input-section button {
+    flex: 1 1 100%;
+  }
+
+  .chart-wrapper {
+    padding: 16px;
+  }
+}
+
+.empty-result {
+  text-align: center;
+  color: #999;
+  font-size: 15px;
+  margin-top: 24px;
+  padding: 20px;
+  background-color: #f6f6f6;
+  border-radius: 10px;
+}
+
+.single-data-note {
+  text-align: center;
+  font-size: 14px;
+  color: #666;
+  background-color: #f8f9fa;
+  padding: 12px 16px;
+  margin-top: -10px;
+  margin-bottom: 16px;
+  border-radius: 6px;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.03);
+  font-style: italic;
+}
+
+
 


### PR DESCRIPTION
## 요약
feat: 실거래가 전세가율 추가

## 내용
- 전세 검색만 가능했던 기능에서 전세/매매 통합 조회 가능한 기능으로 구축
- 각 전세/매매/전세가율 기능 추가
- css 수정

## 이슈
- 전세/매매 둘 다 있는 데이터 필요 (하드코딩으로 예시 넣어둠)
- 전세가율 설명 툴팁 필요

